### PR TITLE
Ad 129: enforce draw period start and end on students

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,14 +30,12 @@ class ApplicationController < ActionController::Base
         current_user.has_completed_form = true
         current_user.save!
       else
-        redirect_to Rails.application.config.form_url
+        if current_user.is_admin
+          flash[:alert] = 'Don\'t forget to fill out the form!'
+        else
+          redirect_to Rails.application.config.form_url
+        end
       end
-    end
-  end
-
-  def check_form_skip_admin
-    unless current_user.is_admin then
-      check_form
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,8 +6,8 @@ class ApplicationController < ActionController::Base
 
   # TODO: Uncomment the line below to enable form/login redirect and comingsoon
   # redirect when draw period isn't live. Make sure also to uncomment the 
-  # corresponding line in `app/controllers/sessions_controller.rb`!
-  before_action :check_login, :check_form, :check_draw_period
+  # corresponding line in sessions controller and draw periods controller!
+  #before_action :check_login, :check_form, :check_draw_period
 
   def current_user
     @current_user ||= User.find_by_id(session[:user_id]) if session[:user_id]

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,13 @@ class ApplicationController < ActionController::Base
   end
 
   def current_draw_period
-    @current_draw_period ||= DrawPeriod.find_by('start_datetime < ? AND ? < end_datetime', DateTime.now, DateTime.now)
+    candidate = DrawPeriod.first
+    
+    if candidate.start_datetime < DateTime.now && candidate.end_datetime > DateTime.now
+      @current_draw_period = candidate
+    else
+      @current_draw_period = nil
+    end
   end
 
   def check_login

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,8 +15,9 @@ class ApplicationController < ActionController::Base
 
   def current_draw_period
     candidate = DrawPeriod.first
-    
-    if candidate.start_datetime < DateTime.now && candidate.end_datetime > DateTime.now
+    if candidate == nil
+      @current_draw_period = nil
+    elsif candidate.start_datetime < DateTime.now && candidate.end_datetime > DateTime.now
       @current_draw_period = candidate
     else
       @current_draw_period = nil

--- a/app/controllers/draw_periods_controller.rb
+++ b/app/controllers/draw_periods_controller.rb
@@ -1,5 +1,5 @@
 class DrawPeriodsController < ApplicationController
-    skip_before_action :check_draw_period, only: [:coming_soon]
+    #skip_before_action :check_draw_period, only: [:coming_soon]
     before_action :set_draw_period, only: [:admin_landing_page, :coming_soon, :update, :destroy]
 
     def create

--- a/app/controllers/draw_periods_controller.rb
+++ b/app/controllers/draw_periods_controller.rb
@@ -1,6 +1,6 @@
 class DrawPeriodsController < ApplicationController
-    before_action :set_draw_period, only: [:admin_landing_page, :update, :destroy]
-    helper DrawPeriodHelper
+    skip_before_action :check_draw_period, only: [:coming_soon]
+    before_action :set_draw_period, only: [:admin_landing_page, :coming_soon, :update, :destroy]
 
     def create
         @draw_period = DrawPeriod.new(draw_period_params)
@@ -34,8 +34,15 @@ class DrawPeriodsController < ApplicationController
         if(@draw_period == nil)
             @draw_period = DrawPeriod.new
         else
-            @start = @draw_period.start_datetime.to_formatted_s(:short)
-            @end = @draw_period.end_datetime.to_formatted_s(:short)
+            @start = format_datetime(@draw_period.start_datetime)
+            @end = format_datetime(@draw_period.end_datetime)
+        end
+    end
+
+    def coming_soon
+        if @draw_period != nil
+            @start = format_datetime(@draw_period.start_datetime)
+            @end = format_datetime(@draw_period.end_datetime)
         end
     end
 
@@ -88,6 +95,10 @@ class DrawPeriodsController < ApplicationController
     end
 
     private
+        def format_datetime(datetime)
+            return datetime.strftime("%B %e, %Y %l:%M %p")
+        end
+
         def set_draw_period
             @draw_period = DrawPeriod.first
         end

--- a/app/controllers/draw_periods_controller.rb
+++ b/app/controllers/draw_periods_controller.rb
@@ -1,8 +1,7 @@
 class DrawPeriodsController < ApplicationController
     skip_before_action :check_draw_period, only: [:coming_soon]
     before_action :set_draw_period, only: [:admin_landing_page, :coming_soon, :update, :destroy]
-    include DrawPeriodHelper
-    
+
     def create
         @draw_period = DrawPeriod.new(draw_period_params)
         

--- a/app/controllers/draw_periods_controller.rb
+++ b/app/controllers/draw_periods_controller.rb
@@ -1,7 +1,8 @@
 class DrawPeriodsController < ApplicationController
     skip_before_action :check_draw_period, only: [:coming_soon]
     before_action :set_draw_period, only: [:admin_landing_page, :coming_soon, :update, :destroy]
-
+    include DrawPeriodHelper
+    
     def create
         @draw_period = DrawPeriod.new(draw_period_params)
         

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,5 @@
 class SessionsController < ApplicationController
-  #skip_before_action :check_login, :check_form
+  skip_before_action :check_login, :check_form, :check_draw_period
 
   def create
     user = User.from_omniauth(request.env['omniauth.auth'])

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,5 @@
 class SessionsController < ApplicationController
-  skip_before_action :check_login, :check_form, :check_draw_period
+  #skip_before_action :check_login, :check_form, :check_draw_period
 
   def create
     user = User.from_omniauth(request.env['omniauth.auth'])

--- a/app/helpers/draw_period_helper.rb
+++ b/app/helpers/draw_period_helper.rb
@@ -1,6 +1,8 @@
 module DrawPeriodHelper
-    def getStatus(draw_period)
-        if draw_period == current_draw_period
+    def status(draw_period)
+        if draw_period == nil
+            @status = "TBA"
+        elsif draw_period == current_draw_period
             @status = "Live"
         elsif draw_period.end_datetime < Time.now
             @status = "Complete"
@@ -9,7 +11,7 @@ module DrawPeriodHelper
         end
     end
 
-    def getLastUpdater(draw_period)
+    def lastUpdater(draw_period)
         @last_updater = User.find_by(id: draw_period.last_updated_by).first_name
         @last_updater += " " + User.find_by(id: draw_period.last_updated_by).last_name
     end

--- a/app/views/draw_periods/_form.html.erb
+++ b/app/views/draw_periods/_form.html.erb
@@ -26,6 +26,6 @@
     </div>
 
     <div class="actions">
-        <%= form.submit %>
+        <%= form.submit params[:method], data: {confirm: 'Are you sure?'} %>
     </div>
 <% end %>

--- a/app/views/draw_periods/admin_landing_page.html.erb
+++ b/app/views/draw_periods/admin_landing_page.html.erb
@@ -20,12 +20,16 @@
 </div> 
 
 <br>
+<div>
 <h4>Schedule Draw Period</h4>
 
 <% if @start != nil %>
-  <p>Currently scheduled for <b><%= @start %></b> to <b><%= @end %></b>
+  <p>Currently scheduled for <b><%= @start %></b> to <b><%= @end %></b>.
     <%= link_to 'Cancel', @draw_period, method: :delete, data: { confirm: 'Are you sure?' } %>
   </p>
 <% end %>
 <%= render 'form', draw_period: @draw_period %>
-
+<% if @start != nil %>
+<p style="color: gray">Last scheduled by <b><i><%= lastUpdater(@draw_period) %></i></b>.</p>
+<% end %>
+</div>

--- a/app/views/draw_periods/coming_soon.html.erb
+++ b/app/views/draw_periods/coming_soon.html.erb
@@ -1,11 +1,13 @@
 <p id="notice"><%= notice %></p>
 
-<h1> Room Draw hasn't started yet. </h1>
-
-<% if @draw_period != nil %>
-    <p>
-    Digital Draw will take place from <strong><%= @start %></strong> to <strong><%= @end %></strong>.
-    </p>
+<% if status(@draw_period) == 'Complete' %>
+    <h1>You're Too Late!</h1>
+    <p>Digital Draw ended on <strong><%= @end %></strong>.</p>
 <% else %>
-    <h2> Date to be announced! </h2>
+    <h1>Coming Soon</h1>
+    <% if @draw_period != nil %>
+        <p>Digital Draw will take place from <strong><%= @start %></strong> to <strong><%= @end %></strong>.</p>
+    <% else %>
+        <p>Date of next Digital Draw to be announced!</p>
+    <% end %>
 <% end %>

--- a/app/views/draw_periods/coming_soon.html.erb
+++ b/app/views/draw_periods/coming_soon.html.erb
@@ -1,5 +1,5 @@
 <p id="notice"><%= notice %></p>
-
+<center>
 <% if status(@draw_period) == 'Complete' %>
     <h1>You're Too Late!</h1>
     <p>Digital Draw ended on <strong><%= @end %></strong>.</p>
@@ -11,3 +11,4 @@
         <p>Date of next Digital Draw to be announced!</p>
     <% end %>
 <% end %>
+</center>

--- a/app/views/draw_periods/coming_soon.html.erb
+++ b/app/views/draw_periods/coming_soon.html.erb
@@ -1,0 +1,11 @@
+<p id="notice"><%= notice %></p>
+
+<h1> Room Draw hasn't started yet. </h1>
+
+<% if @draw_period != nil %>
+    <p>
+    Digital Draw will take place from <strong><%= @start %></strong> to <strong><%= @end %></strong>.
+    </p>
+<% else %>
+    <h2> Date to be announced! </h2>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
   
+  get 'coming_soon', to: 'draw_periods#coming_soon'
+  
   resources :emails
   get 'emails/new', to: 'draw_periods#sendEmails'
   get 'emails/index'
@@ -25,8 +27,7 @@ Rails.application.routes.draw do
   post 'admin/uploadRoster', to: 'draw_periods#uploadRoster'
   post 'admin/downloadNonParticipants', to: 'draw_periods#downloadNonParticipants'
   post 'admin/downloadPlacements', to: 'draw_periods#downloadPlacements'
-
-  resources :draw_periods
+  resources :draw_periods, only: [:create, :update, :destroy]
 
   resources :dorms
   resources :pulls


### PR DESCRIPTION
If a student logs in when room draw isn't happening yet, they should be redirected to a page with a  "coming soon" message and not be allowed to do any actions. Also added some helpful info to the draw period area of landing page.

Do we want students to be able to view anything? For now they can do nothing, but let me know if that should change.

@sxmichaels Added you as reviewer because I also changed your check_form method and deleted your check_form_not_admin method. Feel free to look over everything, though!

See Issue #129 