### PR TITLE
Users shouldnt see the edit dorms page

### DIFF
--- a/app/views/dorms/show.html.erb
+++ b/app/views/dorms/show.html.erb
@@ -92,8 +92,8 @@
   <p>
     <% if current_user.is_admin? %>
       <%= link_to 'Edit', edit_dorm_path(@dorm) %> |
-    <% end %>
       <%= link_to 'Go Back', dorms_path %>
+    <% end %>
     </br>
   </p>
 </div>


### PR DESCRIPTION
It's admin-only.  Users have their own dorm list on their homepage