### PR TITLE
Map pulls

### DIFF
--- a/app/controllers/dorms_controller.rb
+++ b/app/controllers/dorms_controller.rb
@@ -36,14 +36,17 @@ class DormsController < ApplicationController
     6.times {@pull.room_assignments.build}
     @adminPull = Pull.new
     1.times {@adminPull.room_assignments.build}
+    @students = Student.all
     #TODO: Get only the necessary information
-    # @students = Student.all
     @users = User.all
-    # @rooms = Room.all
     @dorms = Dorm.all
     #join tables
-    @students = Student.joins(:user).select('users.first_name, users.last_name, users.email, students.*').order("email ASC").select{ |s| not s.room_assignment and s.has_completed_form }
-    
+    @studentData = Student.joins(:user).select('users.first_name, users.last_name, users.email, students.*').order("email ASC").select{ |s| not s.room_assignment and s.has_completed_form }
+    @room_ids = @rooms.map{|r| r.number}.to_json.html_safe
+    @dorms_index = get_dorm_index()
+
+
+
     if current_user
       if !current_user.student.nil?
         @curPullNum = current_user.student.room_draw_number    
@@ -136,9 +139,6 @@ class DormsController < ApplicationController
   # GET /dorms/1/edit
   def edit
     authorize @dorm
-    # @students = Student.all
-    # @rooms = Room.all
-    # @dorms = Dorm.all
   end
 
   # POST /dorms
@@ -198,6 +198,18 @@ class DormsController < ApplicationController
     # Use callbacks to share common setup or constraints between actions.
     def set_pull
       @pull = Pull.find(params[:id])
+    end
+
+    # Count how many rooms are before this room out of all Rooms
+    # This function helps us populate the adming Pulls form with the correct data
+    def get_dorm_index
+      count = 1
+      Dorm.all.each do |d|
+        if d == @dorm
+          return count
+        end
+        count += d.rooms.count
+      end
     end
 
     # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/controllers/dorms_controller.rb
+++ b/app/controllers/dorms_controller.rb
@@ -36,12 +36,12 @@ class DormsController < ApplicationController
     6.times {@pull.room_assignments.build}
     @adminPull = Pull.new
     1.times {@adminPull.room_assignments.build}
-    @students = Student.all
     #TODO: Get only the necessary information
     @users = User.all
     @dorms = Dorm.all
     #join tables
-    @studentData = Student.joins(:user).select('users.first_name, users.last_name, users.email, students.*').order("email ASC").select{ |s| not s.room_assignment and s.has_completed_form }
+    @students = Student.joins(:user).select('users.first_name, users.last_name, users.email, students.*').order("email ASC").select{ |s| not s.room_assignment and s.has_completed_form }
+    puts "STUDENTS IS", @students.count
     @room_ids = @rooms.map{|r| r.number}.to_json.html_safe
     @dorms_index = get_dorm_index()
 

--- a/app/controllers/dorms_controller.rb
+++ b/app/controllers/dorms_controller.rb
@@ -41,7 +41,6 @@ class DormsController < ApplicationController
     @dorms = Dorm.all
     #join tables
     @students = Student.joins(:user).select('users.first_name, users.last_name, users.email, students.*').order("email ASC").select{ |s| not s.room_assignment and s.has_completed_form }
-    puts "STUDENTS IS", @students.count
     @room_ids = @rooms.map{|r| r.number}.to_json.html_safe
     @dorms_index = get_dorm_index()
 

--- a/app/controllers/dorms_controller.rb
+++ b/app/controllers/dorms_controller.rb
@@ -34,6 +34,8 @@ class DormsController < ApplicationController
     @rooms = @dorm.rooms
     @pull = Pull.new
     6.times {@pull.room_assignments.build}
+    @adminPull = Pull.new
+    1.times {@adminPull.room_assignments.build}
     #TODO: Get only the necessary information
     # @students = Student.all
     @users = User.all

--- a/app/controllers/pulls_controller.rb
+++ b/app/controllers/pulls_controller.rb
@@ -21,7 +21,7 @@ class PullsController < ApplicationController
     @pull = Pull.new
     1.times {@pull.room_assignments.build}
     #TODO: Get only the necessary information
-    @students = Student.all
+    @students = Student.joins(:user).select('users.first_name, users.last_name, users.email, students.*').order("email ASC").select{ |s| not s.room_assignment and s.has_completed_form }
     @rooms = Room.all
     @dorms = Dorm.all
   end

--- a/app/views/dorms/show.html.erb
+++ b/app/views/dorms/show.html.erb
@@ -346,6 +346,8 @@ $(".alert-div").fadeOut(8000);
     var dormId = <%= @dorm.id %>;
     var admin = <%= @admin %>;
     var is_student = <%= @is_student %>;
+    var room_ids = <%= @room_ids %>;
+    var dorms_index = <%= @dorms_index %>;
 
 
 function layout(level){  
@@ -408,6 +410,10 @@ function layout(level){
         border: '5px solid black',
     }).appendTo('body');
     dormElements.push(fakeDorm);
+
+    function get_room_index(x) {
+      return dorms_index + room_ids.indexOf(x);
+    }
 
 
     //get keys so that you can traverse js by index
@@ -527,6 +533,9 @@ function layout(level){
                       $('#room_number').val(info.number); //TODO: Check this is actually used.
                       $('#unpullable-room-delete').val(info.number);
                       $('#unpullable-room-num').val(info.number);
+                      var index = get_room_index(info.number);
+                      $('#pull_room_assignments_attributes_0_room_id').val(index);
+                      
                       $('#pull-student').addClass('hidden');
 
                       if (info.assignment_type != null) { // If there's currently a room assignment

--- a/app/views/dorms/show.html.erb
+++ b/app/views/dorms/show.html.erb
@@ -139,7 +139,7 @@
           
           <button id="create-pull" class="btn btn-primary btn-block popup-button">Create Pull</button>
           <div class="hidden popup-button toggle-form" id="pull-form">
-              <%= render 'pulls/adminForm', pull: @pull, locals: {redirect_path: dorm_path(@dorm)} %>
+              <%= render 'pulls/adminForm', pull: @adminPull, locals: {redirect_path: dorm_path(@dorm)} %>
           </div>
 
           <button id="edit-pull" class="btn btn-primary btn-block popup-button">Edit Pull</button>

--- a/app/views/pulls/_adminForm.html.erb
+++ b/app/views/pulls/_adminForm.html.erb
@@ -33,6 +33,7 @@
       <div>
         <%= room_assignment.label :student_id %>
         <%= room_assignment.collection_select :student_id, @students, :id, :room_draw_number, id: :room_assignment_student_id %>
+
       </div>
       <div>
         <%= room_assignment.label :room_id %>
@@ -41,7 +42,7 @@
 
       <div>
         <%= room_assignment.label :assignment_type %>
-        <%= room_assignment.select :assignment_type, RoomAssignment.assignment_types.keys.to_a %>
+        <%= room_assignment.select :assignment_type, RoomAssignment.assignment_types.keys.to_a, :selected => 'pulled' %>
       </div> 
       
     <% end %>

--- a/app/views/pulls/_adminForm.html.erb
+++ b/app/views/pulls/_adminForm.html.erb
@@ -16,7 +16,8 @@
     <%= form.label :student_id %>
     <!-- TODO: We don't wanna display room_draw_numner.
          So, we need to join the table of student and user and get the email address -->
-    <%= form.collection_select :student_id, @students, :id, :room_draw_number  %>
+    <%= form.collection_select :student_id, @students, :id, :email, id: :student_id %>
+
   </div>
 
   <div class="field">
@@ -30,10 +31,9 @@
   <%= field_set_tag 'Room Assignments' do %>
 
     <%= form.fields_for :room_assignments do |room_assignment| %>
-      <div>
+      <div> 
         <%= room_assignment.label :student_id %>
-        <%= room_assignment.collection_select :student_id, @students, :id, :room_draw_number, id: :room_assignment_student_id %>
-
+        <%= room_assignment.collection_select :student_id, @students, :id, :email, id: :room_assignment_student_id %>
       </div>
       <div>
         <%= room_assignment.label :room_id %>


### PR DESCRIPTION
This PR makes the map and Pulls-page interface more similar, along with auto-populating the Room field when pulling from the admin map.

Known bugs remaining with the admin pull form:
- From the map, the Pull form does not redirect back to the map
- When you add a student to a pull, if you get an error, dropdowns turn into text fields
- "Add student to Pull" should either be embedded in the map (ideal) or redirect back to it
- After adding a student to a pull, you should redirected back to the previous page (not to the RoomAssignments page, as currently done)